### PR TITLE
Fixed issue when running github action to create draft release w/ buit packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install rumps==0.4.0
-        pip install py2app==0.28.8
-        pip install feedparser==6.0.12
+        pip install --upgrade -r requirements.txt
         brew update
         brew install create-dmg
     - name: Build Application

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,7 @@ OPTIONS = {
 
 REQ_LIST = [
     "feedparser==6.0.12",
-    "py2app>=0.28.8",
-    "rumps>=0.4.0",
+    "rumps==0.4.0",
 ]
 
 setup(
@@ -26,7 +25,7 @@ setup(
     include=["__about__"],
     data_files=DATA_FILES,
     options={"py2app": OPTIONS},
-    setup_requires=REQ_LIST,
+    install_requires=REQ_LIST,
     name="MergeRequestsMonitor",
     version=__version__,
 )


### PR DESCRIPTION
#### Changes Made

1. `.github/workflows/release.yml` •  Simplified dependency installation to use pip install --upgrade -r requirements.txt •  This ensures all dependencies are installed from the requirements.txt file with exact versions •  Removed individual package installations that were redundant

2. `setup.py` •  Changed from setup_requires to install_requires (the former is deprecated) •  Removed py2app from the requirements list in setup.py since it's a build tool, not a runtime dependency •  Changed version specifiers from >= to == to match requirements.txt exactly

Why This Fixes the Issue

The error occurred because:
1. The workflow was installing packages individually, which could lead to version conflicts
2. setup.py was using setup_requires with a different version specifier (>=0.28.8) than what was being installed
3. The deprecated setup_requires parameter can cause issues with dependency resolution

Now:
•  Dependencies are installed consistently from requirements.txt with exact versions •  setup.py only declares runtime dependencies (feedparser and rumps), not build tools (py2app) •  The --upgrade flag ensures we get the specified versions without conflicts

The workflow should now run successfully and create your draft release with the DMG and ZIP artifacts!