### PR TITLE
Exclude TK and Tcl from codesigning due to build error in GH action

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,4 +28,8 @@ setup(
     install_requires=REQ_LIST,
     name="MergeRequestsMonitor",
     version=__version__,
+    dylib_excludes=[
+        "/Library/Frameworks/Python.framework/Versions/3.13/Frameworks/Tcl.framework",
+        "/Library/Frameworks/Python.framework/Versions/3.13/Frameworks/Tk.framework",
+    ],
 )


### PR DESCRIPTION
See https://github.com/ronaldoussoren/py2app/issues/546